### PR TITLE
fix files grouping example, make pytest-able

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -155,7 +155,8 @@ Group employees by department::
 
 Group files by extension::
 
-    grouping(os.listdir('.'), key=lambda filepath: os.path.splitext(filepath)[1])
+    grouping((entry for entry in os.scandir('.') if entry.is_file()),
+             key=lambda entry: os.path.splitext(entry)[1])
 
 
 Group transactions by type::
@@ -322,10 +323,10 @@ comparison in this situation would be ``Series.groupby`` [#]_.
     In [1]: import pandas as pd
 
     In [2]: def mod(x):
-    ...:     def modulo(n):
-    ...:         return n % x
-    ...:     return modulo
-    ...:
+       ...:     def modulo(n):
+       ...:         return n % x
+       ...:     return modulo
+       ...:
 
     In [3]: pd.Series(range(10)).groupby(mod(2)).groups
     Out[3]:

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -30,10 +30,11 @@ lists based on an iterable and a key-function.
 
 ::
 
-    from itertools import groupby as _groupby
+    from itertools import groupby
+
 
     def grouping(iterable, key=None):
-        '''
+        """
         Group elements of an iterable into a dict of lists.
 
         The ``key`` is a function computing a key value for each
@@ -44,9 +45,9 @@ lists based on an iterable and a key-function.
             >>> grouping('AbBa', key=str.casefold)
             {'a': ['A', 'a'], 'b': ['b', 'B']}
 
-        '''
+        """
         groups = {}
-        for k, g in _groupby(iterable, key):
+        for k, g in groupby(iterable, key):
             groups.setdefault(k, []).extend(g)
         return groups
 
@@ -307,9 +308,10 @@ as the first parameter.
 
 ::
 
+   >>> import toolz
    >>> names = ['Alice', 'Bob', 'Charlie', 'Dan', 'Edith', 'Frank']
-   >>> groupby(len, names)  
-   {3: ['Bob', 'Dan'], 5: ['Alice', 'Edith', 'Frank'], 7: ['Charlie']}
+   >>> sorted(toolz.groupby(len, names).items())
+   [(3, ['Bob', 'Dan']), (5, ['Alice', 'Edith', 'Frank']), (7, ['Charlie'])]
 
 
 Pandas
@@ -376,8 +378,9 @@ value)`` pairs.
 
 ::
 
-    from itertools import groupby as _groupby
+    from itertools import groupby
     from operator import itemgetter
+
 
     def grouping(iterable, key=itemgetter(0)):
         '''
@@ -389,12 +392,12 @@ value)`` pairs.
 
         By default, the key-function gets the 0th index of each element.
 
-            >>> grouping(['apple', 'banana', 'aardvark'])
+            >>> grouping(['apple', 'banana', 'aardvark'])       # doctest: +SKIP
             {'a': ['apple', 'aardvark'], 'b': ['banana']}
 
         '''
         groups = {}
-        for k, g in _groupby(iterable, key):
+        for k, g in groupby(iterable, key):
             groups.setdefault(k, []).extend(g)
         return groups
 
@@ -479,7 +482,8 @@ same data type for input and output.
    >>> actors = ['Graham', 'Eric', 'Terry', 'Terry', 'John', 'Michael']
    >>> sorted(actors)
    ['Eric', 'Graham', 'John', 'Michael', 'Terry', 'Terry']
-   >>> sorted(actors, key=len)
+   >>> sorted_actors = sorted(actors, key=len)
+   >>> sorted_actors
    ['Eric', 'John', 'Terry', 'Terry', 'Graham', 'Michael']
 
 
@@ -489,7 +493,7 @@ consider the possibilities before demonstrating the results.
 
 ::
 
-   >>> grouping(actors, key=len)
+   >>> grouping(sorted_actors, key=len)
    {4: ['Eric', 'John'], 5: ['Terry', 'Terry'], 6: ['Graham'], 7: ['Michael']}
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -383,7 +383,7 @@ value)`` pairs.
 
 
     def grouping(iterable, key=itemgetter(0)):
-        '''
+        """
         Group elements of an iterable into a dict of lists.
 
         The ``key`` is a function computing a key value for each
@@ -395,7 +395,7 @@ value)`` pairs.
             >>> grouping(['apple', 'banana', 'aardvark'])       # doctest: +SKIP
             {'a': ['apple', 'aardvark'], 'b': ['banana']}
 
-        '''
+        """
         groups = {}
         for k, g in groupby(iterable, key):
             groups.setdefault(k, []).extend(g)


### PR DESCRIPTION
Hi, great PEP! :1st_place_medal: Hope BDFL likes it!

Here's my minor contribution as I've read it very carefully and couldn't find anything wrong really. :wink:

I have made so it's self-testing! You can run pytest on the `pep-9999.rst` file. I deliberately skipped adding `conftest.py`, but it *could* be considered:

```shell
$ cat conftest.py 
from itertools import groupby

import pytest


def pep_9999_grouping(iterable, key=None):
    """
    Group elements of an iterable into a dict of lists.

    The ``key`` is a function computing a key value for each
    element.  Each key corresponds to a group -- a list of elements
    in the same order as encountered.  By default, the key will be
    the element itself.

        >>> grouping('AbBa', key=str.casefold)                            
        {'a': ['A', 'a'], 'b': ['b', 'B']}

    """
    groups = {}
    for k, g in groupby(iterable, key):
        groups.setdefault(k, []).extend(g)
    return groups


@pytest.fixture(autouse=True)
def add_grouping(doctest_namespace):
    doctest_namespace['grouping'] = pep_9999_grouping
    doctest_namespace['groupby'] = groupby

$ pytest pep-9999.rst | tail -5
collected 1 item

pep-9999.rst .                                                           [100%]

=========================== 1 passed in 0.02 seconds ===========================

```